### PR TITLE
383 - Updating Piunora card

### DIFF
--- a/_boards_cm/piunora-metro-ff-m2.md
+++ b/_boards_cm/piunora-metro-ff-m2.md
@@ -2,10 +2,10 @@
 layout: board
 title: "Piunora - CM4 in Metro/Arduino form factor"
 short_description: M.2 underneath, Arduino-style connections up top.
-status: prototype
+status: production
 picture: "/images/board-piunora-metro-ff-m2.jpg"
 github_issue: "https://github.com/geerlingguy/raspberry-pi-pcie-devices/issues/25#issuecomment-742956897"
-link: https://www.crowdsupply.com/diodes-delight/piunora
+link: https://www.diodes-delight.com/products/piunora/
 videos:
   - https://www.youtube.com/watch?v=4vSGl5kpf-k
   - https://www.youtube.com/watch?v=7Li7Nh9V74I


### PR DESCRIPTION
For issue #383 - Changed status from prototype to production and updated the link to https://www.diodes-delight.com/products/piunora/.