### PR TITLE
Change `-j` Argument to be More Generic

### DIFF
--- a/extras/cross-compile/README.md
+++ b/extras/cross-compile/README.md
@@ -44,12 +44,12 @@ You will be dropped into a shell inside the container's `/build` directory. From
   1. Compile the Kernel:
 
      ```
-     make -j8 ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- Image modules dtbs
+     make -j -l`nproc` ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- Image modules dtbs
      ```
 
 > For 32-bit Pi OS, use `ARCH=arm`, `CROSS_COMPILE=arm-linux-gnueabihf-`, and `zImage` instead of `Image`.
 
-> I set the jobs argument (`-j8`) based on a bit of benchmarking on my M1 Mac's processor. For different types of processors you may want to use more (or fewer) jobs depending on architecture and how many cores you have.
+> The job argument `-j` is set to unlimted here with make limiting the workload placed on the nuild machine with `-l`. The limiy is based off of total CPU useage, each hardware thread allowing the usage to go up another 100% (which translates to `1` here). This should allow you to keep using your computer with hte build happening but without it taking too much time. If the build fails try using `-jN` where `N` is a number smaller than your core count to reduce memory usage.
 
 ## Copying built Kernel via remote SSHFS filesystem
 


### PR DESCRIPTION
Make allows for a nice trick when specifying how how many jobs to use. If you pass -jwithout a number it allows make to use as many jobs as it can. But if you pass the -l flag it will prevent make from spawning more jobs if the CPU load is at or above the number you specify. (Just in case, CPU load isn't 0-100 like on Windows, it is 0-N where N is the count of hardware threads you have. So on machine with 10 threads a load of 1.1 would be 11%) This makes it so make won't completely overwhelm your system and allows you to do other things, since these other things put load on the CPU.

The CPU limit I provide with this change comes from the nproc command which gets the number of threads the system has. This number is provided to make by using the backtick syntax which replaces the part of the commamd surrounded by backytcks (inclusive) with the output of the executed command.

I'm sorry if this is over explaining, I just found your content and I'm not yet familiar with how much you know about these tools.

I did this all in the web UI, normally I use the `git` command for the commits. I accidently made two out of this one, you can squash the commits if you want.