### PR TITLE
Update Sangoma and Digium T1 cards

### DIFF
--- a/_cards_other/digium-te420.md
+++ b/_cards_other/digium-te420.md
@@ -18,7 +18,7 @@ DIGIUM TE420 FEATURES:
 
 ### Installation Notes
 
-Add the following to ```boot/config.txt```:
+This card supports both 32-bit and 64-bit kernels, and needs the following added to ```boot/config.txt``` in order to support 32-bit DMA:
 
 ```
 # Force PCIe config to support 32bit DMA addresses at the expense of

--- a/_cards_other/sangoma-a10x.md
+++ b/_cards_other/sangoma-a10x.md
@@ -2,7 +2,7 @@
 layout: card
 title: "Sangoma Technologies Corp. A10x T1/E1 AFT cards"
 picture: "/images/other-sangoma-a108.png"
-functionality: "Not working"
+functionality: "Full (32-bit kernel only)"
 driver_required: "Yes"
 github_issue: "https://github.com/geerlingguy/raspberry-pi-pcie-devices/issues/471"
 buy_link: https://www.amazon.com/Sangoma-A101E/dp/B001BDI8KY/
@@ -17,12 +17,24 @@ Choose from 1 port of T1/E1 up to 16 ports all using only one (1) PCI or PCI Exp
 
 ### Installation
 
-Kernel driver: [Wanpipe](https://wiki.freepbx.org/display/DAS/Telephony+Card+Driver+Download)
+This driver only supports 32-bit kernels, and needs the following added to ```boot/config.txt``` in order to support 32-bit DMA:
 
-Needs some changes for ARM.
+```
+# Force PCIe config to support 32bit DMA addresses at the expense of
+# having to bounce buffers.
+dtoverlay=pcie-32bit-dma
+```
+
+Kernel drivers:
+
+* [Patched driver](https://github.com/hharte/wanpipe-rpi-cm4) with changes to support support the Raspberry Pi CM4 (32-bit kernel only.)
+* Original [Wanpipe](https://wiki.freepbx.org/display/DAS/Telephony+Card+Driver+Download) driver from Sangoma.
 
 To compile, run "./Setup dahdi --silent"
 
 ### Status
 
-Not currently working, due to attempt to use IRQ 255.
+Currently working with [patched driver](https://github.com/hharte/wanpipe-rpi-cm4) on 32-bit kernels only.
+
+Support for 64-bit kernels is unlikely as the driver makes extensive use of non-64-bit aligned bitops functions, which are not supported on ARM processors, and lead to an alignment trap.
+


### PR DESCRIPTION
* Update working status.
* Add notes for 32- and 64-bit kernels.
* Add link to patched Wanpipe driver for RPi CM4.