### PR TITLE
Update boards_cm.md

### DIFF
--- a/boards_cm.md
+++ b/boards_cm.md
@@ -82,4 +82,4 @@ The following boards are either not yet commercially available or one-offs and _
 ## About
 {: .no_toc}
 
-This project is maintained by [Jeff Geerling](https://www.jeffgeerling.com). The Raspberry Pi Compute Module 4 is a product of [Raspberry Pi (Trading) Limited](https://www.raspberrypi.org/about/).
+This project is maintained by [Jeff Geerling](https://www.jeffgeerling.com). Raspberry Pi is a product of [Raspberry Pi Ltd](https://www.raspberrypi.com).


### PR DESCRIPTION
Correct Raspberry Pi company name.

Unfortunately Raspberry Pi Ltd, for unknown reasons, don't state anywhere on their website that they are the company that develop Raspberry Pi devices, so just replace obsolete link to .org/about with link to the .com homepage. (Company details are buried in website terms and conditions, but that only says the website is run by Raspberry Pi Ltd grrr).